### PR TITLE
frontend/src/components/Footer.tsx: fix mijnrood link in footer

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -15,7 +15,7 @@ export default function Footer() {
                 <Link href="/privacybeleid">
                     <a className="hover:underline">Privacybeleid</a>
                 </Link>
-                <a href="https://mijn.roodjongeren.nl/login"
+                <a href="https://mijn.roodjongeren.nl"
                    className="hover:underline">
                     mijnROOD
                 </a>


### PR DESCRIPTION
if we are already logged in at mijnrood and we press this link
we get error 403 because we cannot go to /login again, we are
after all, already logged in

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>