### PR TITLE
backend/*: add mailer provider

### DIFF
--- a/backend/config/plugins.js
+++ b/backend/config/plugins.js
@@ -3,4 +3,21 @@ module.exports = ({env}) => ({
   'users-permissions': {
     jwtSecret: env('JWT_SECRET')
   }
+  email: {
+    config: {
+      provider: 'nodemailer',
+      providerOptions: {
+        host: env('SMTP_HOST', 'mail.zxcs.nl'),
+        port: env('SMTP_PORT', 465),
+        auth: {
+          user: env('SMTP_USERNAME'),
+          pass: env('SMTP_PASSWORD'),
+        },
+      },
+      settings: {
+        defaultFrom: 'noreply-website@roodjongeren.nl',
+        defaultReplyTo: 'info@roodjongeren.nl',
+      },
+    },
+  },
 });

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@strapi/plugin-i18n": "4.2.3",
     "@strapi/plugin-users-permissions": "4.2.3",
+    "@strapi/provider-email-nodemailer": "^4.4.3",
     "@strapi/strapi": "4.2.3",
     "pg": "^8.7.3"
   },

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1714,6 +1714,14 @@
     request "^2.83.0"
     url-join "4.0.1"
 
+"@strapi/provider-email-nodemailer@^4.4.3":
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/@strapi/provider-email-nodemailer/-/provider-email-nodemailer-4.4.3.tgz#0707c6f952547294352215588d5a861f48ef12a6"
+  integrity sha512-HKBjdalpKHIjsETTa4Ya5LUJt0TnQc0qWK8HA5e2yEKM8X/lxKJbft1caqTtyMRUco2EfgccGEt4F/179R7AQA==
+  dependencies:
+    lodash "4.17.21"
+    nodemailer "6.7.7"
+
 "@strapi/provider-email-sendmail@4.2.3":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@strapi/provider-email-sendmail/-/provider-email-sendmail-4.2.3.tgz#09efa7e5b5e39ea64a7cd3c73b2763dc0773a32f"
@@ -7181,6 +7189,11 @@ nodemailer-shared@1.1.0:
   integrity sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=
   dependencies:
     nodemailer-fetch "1.6.0"
+
+nodemailer@6.7.7:
+  version "6.7.7"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.7.7.tgz#e522fbd7507b81c51446d3f79c4603bf00083ddd"
+  integrity sha512-pOLC/s+2I1EXuSqO5Wa34i3kXZG3gugDssH+ZNCevHad65tc8vQlCQpOLaUjopvkRQKm2Cki2aME7fEOPRy3bA==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Configuration needs to be added to the production env

This should work according to the example here: https://market.strapi.io/providers/@strapi-provider-email-nodemailer

Still needs testing in production to see if it will actually send an email.

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>