### PR TITLE
chore(docker-dev): make host port mappings configurable

### DIFF
--- a/docker/roodjongeren_dev/.env
+++ b/docker/roodjongeren_dev/.env
@@ -13,3 +13,17 @@ DATABASE_PORT=5432
 DATABASE_NAME=rood
 DATABASE_USER=rood
 DATABASE_PASSWORD=y75STZgtJ4tqNPmd
+
+# Host port mappings for docker-compose. Override any of these to avoid
+# collisions when running multiple project stacks side by side. The
+# container-internal ports (right side of the mapping in docker-compose.yml)
+# stay at the service defaults, so app config inside containers is unchanged.
+#
+# If POSTGRES_HOST_PORT is overridden, DATABASE_PORT above must match it so
+# Strapi (which runs on the host, not inside the compose network) connects
+# to the right port.
+#
+# POSTGRES_HOST_PORT=15432
+# NGINX_HOST_PORT=8081
+# MAILCATCHER_SMTP_HOST_PORT=11025
+# MAILCATCHER_WEB_HOST_PORT=11080

--- a/docker/roodjongeren_dev/docker-compose.yml
+++ b/docker/roodjongeren_dev/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=$DATABASE_PASSWORD
       - POSTGRES_DB=$DATABASE_NAME
     ports:
-      - '5432:5432'
+      - '${POSTGRES_HOST_PORT:-5432}:5432'
     volumes:
       - postgres_volume:/var/lib/postgresql/data
       - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
@@ -18,7 +18,7 @@ services:
     environment:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx
     ports:
-      - "80:80"
+      - '${NGINX_HOST_PORT:-80}:80'
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     extra_hosts:
@@ -27,8 +27,8 @@ services:
     container_name: rood_mailcatcher
     image: sj26/mailcatcher:v0.8.1
     ports:
-      - "1025:1025"
-      - "1080:1080"
+      - '${MAILCATCHER_SMTP_HOST_PORT:-1025}:1025'
+      - '${MAILCATCHER_WEB_HOST_PORT:-1080}:1080'
 volumes:
   postgres_volume:
     name: rood_postgres_volume


### PR DESCRIPTION
## Summary
Avoid port-5432 collisions with other client projects' dev stacks by making every host-side port in the dev compose file overridable via env var. Container-internal ports stay at the service defaults so app config inside containers is untouched.

Overridable in `docker/roodjongeren_dev/.env`:
- `POSTGRES_HOST_PORT` (default 5432)
- `NGINX_HOST_PORT` (default 80)
- `MAILCATCHER_SMTP_HOST_PORT` (default 1025)
- `MAILCATCHER_WEB_HOST_PORT` (default 1080)

If `POSTGRES_HOST_PORT` is moved, update `DATABASE_PORT` in the same `.env` so Strapi (running on the host) connects to the new port.

Production stack is untouched.

## Why
Useful for anyone running multiple project stacks side by side. Unblocks running the Strapi 5 verification stack (#380) alongside other Postgres-on-5432 setups locally.