### PR TITLE
refactor(frontend): centralize Strapi response unwrapping

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -3,6 +3,10 @@
 import transpile from "next-transpile-modules";
 import axios from "axios";
 import qs from "qs";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const withTM = transpile(["react-icons/fa", "react-icons/lib"]);
 
@@ -290,6 +294,9 @@ const postsToRedirect = [
 
 export default withTM({
     reactStrictMode: true,
+    // Pin the trace root to this directory. The repo root has a prettier-only
+    // `yarn.lock` that confuses Next's workspace inference.
+    outputFileTracingRoot: __dirname,
     async rewrites() {
         return [
             { source: "/nieuws", destination: "/actueel" },

--- a/frontend/src/models/strapi.ts
+++ b/frontend/src/models/strapi.ts
@@ -27,3 +27,47 @@ export interface StrapiImage {
     width: number;
     height: number;
 }
+
+export interface StrapiMediaFormats {
+    large?: { url: string };
+    medium?: { url: string };
+    small?: { url: string };
+    thumbnail?: { url: string };
+}
+
+export type StrapiMediaAttributes = StrapiImage & {
+    formats?: StrapiMediaFormats;
+};
+
+export type StrapiMediaField =
+    | { data: StrapiCollection<StrapiMediaAttributes> | null }
+    | undefined
+    | null;
+
+export type StrapiRelationField<T> =
+    | { data: StrapiCollection<T> | null }
+    | undefined
+    | null;
+
+/**
+ * Models in this folder describe the *sanitised* shape that components consume
+ * (e.g. `banner: string`). The Strapi API returns those same fields wrapped in
+ * `{ data: { attributes: { url } } }`. `WithRawMedia` rewrites the named keys
+ * back to the raw Strapi shape so a fetcher can type the response without
+ * `any` and unwrap explicitly:
+ *
+ *   type HomeContentRaw = WithRawMedia<HomeContent, "banner">;
+ *   const raw = unwrapEntity<HomeContentRaw>(response);
+ *   return { ...raw, banner: unwrapMediaUrl(raw.banner) };
+ */
+export type WithRawMedia<T, K extends keyof T> = Omit<T, K> & {
+    [P in K]: StrapiMediaField;
+};
+
+/**
+ * Same idea as `WithRawMedia` but for single relations — rewrites the named
+ * keys to the raw `{ data: { attributes } }` relation shape.
+ */
+export type WithRawRelation<T, K extends keyof T, R> = Omit<T, K> & {
+    [P in K]: StrapiRelationField<R>;
+};

--- a/frontend/src/utils/backend.ts
+++ b/frontend/src/utils/backend.ts
@@ -18,6 +18,17 @@ import Fallback from "../models/Fallback";
 import { PetitionDetail } from "../models/Petition";
 import WorkgroupPageContent from "../models/WorkgroupPageContent";
 import { Boardmember } from "../models/Boardmember";
+import {
+    pickLargestMediaFormatUrl,
+    unwrapEntity,
+    unwrapFirstEntity,
+    unwrapList,
+    unwrapMediaFormats,
+    unwrapMediaUrl,
+    unwrapPagination,
+    unwrapRelation,
+    unwrapRelationWithId,
+} from "./strapi-response";
 
 export const backendBaseUrl =
     process.env.BACKEND_URL ?? process.env.NEXT_PUBLIC_BACKEND_URL ?? "";
@@ -40,10 +51,13 @@ export async function fetchFallback(): Promise<Fallback> {
         },
     });
 
-    const content = response.data.data.attributes;
-
+    const content = unwrapEntity(response);
     return {
-        pageBanner: content.pageBanner.data.attributes?.url ?? null,
+        // `pageBanner` is typed as `string` but is nullable at runtime when
+        // no fallback banner is set in Strapi. Fixing the type cascades into
+        // `Banner` and every page that reads `pageBanner`, so the cast stays
+        // until that wider cleanup happens.
+        pageBanner: unwrapMediaUrl(content.pageBanner) as string,
     };
 }
 
@@ -58,12 +72,9 @@ export async function fetchHome(): Promise<HomeContent> {
         },
     });
 
-    function sanitise(content: any) {
-        content.banner = content.banner.data?.attributes?.url ?? null;
-        return content;
-    }
-
-    return sanitise(response.data.data.attributes);
+    const content = unwrapEntity<any>(response);
+    content.banner = unwrapMediaUrl(content.banner);
+    return content;
 }
 
 export async function fetchAboutUs(): Promise<AboutUsContent> {
@@ -77,12 +88,9 @@ export async function fetchAboutUs(): Promise<AboutUsContent> {
         },
     });
 
-    function sanitise(content: any) {
-        content.banner = content.banner.data.attributes.url;
-        return content;
-    }
-
-    return sanitise(response.data.data.attributes);
+    const content = unwrapEntity<any>(response);
+    content.banner = unwrapMediaUrl(content.banner);
+    return content;
 }
 
 export async function fetchBoardmembers(): Promise<Boardmember[]> {
@@ -97,12 +105,10 @@ export async function fetchBoardmembers(): Promise<Boardmember[]> {
         },
     });
 
-    function sanitise(boardmember: any): Boardmember {
-        boardmember.photo = boardmember.photo.data?.attributes?.url ?? null;
+    return unwrapList<any>(response).map((boardmember) => {
+        boardmember.photo = unwrapMediaUrl(boardmember.photo);
         return boardmember;
-    }
-
-    return response.data.data.map((it) => sanitise(it.attributes));
+    });
 }
 
 export async function fetchProgram(): Promise<ProgramContent> {
@@ -116,12 +122,9 @@ export async function fetchProgram(): Promise<ProgramContent> {
         },
     });
 
-    function sanitise(content: any) {
-        content.banner = content.banner.data.attributes.url;
-        return content;
-    }
-
-    return sanitise(response.data.data.attributes);
+    const content = unwrapEntity<any>(response);
+    content.banner = unwrapMediaUrl(content.banner);
+    return content;
 }
 
 export async function fetchJoinUs(): Promise<JoinUsContent> {
@@ -135,12 +138,9 @@ export async function fetchJoinUs(): Promise<JoinUsContent> {
         },
     });
 
-    function sanitise(content: any) {
-        content.banner = content.banner.data.attributes.url;
-        return content;
-    }
-
-    return sanitise(response.data.data.attributes);
+    const content = unwrapEntity<any>(response);
+    content.banner = unwrapMediaUrl(content.banner);
+    return content;
 }
 
 export async function fetchSupportUs(): Promise<SupportUsContent> {
@@ -154,19 +154,16 @@ export async function fetchSupportUs(): Promise<SupportUsContent> {
         },
     });
 
-    function sanitise(content: any) {
-        content.banner = content.banner.data.attributes.url;
-        return content;
-    }
-
-    return sanitise(response.data.data.attributes);
+    const content = unwrapEntity<any>(response);
+    content.banner = unwrapMediaUrl(content.banner);
+    return content;
 }
 
 export async function fetchPrivacybeleid(): Promise<PrivacybeleidContent> {
     const response = await backend.get<StrapiResponse<PrivacybeleidContent>>(
         "/privacybeleid"
     );
-    return response.data.data.attributes;
+    return unwrapEntity(response);
 }
 
 export async function fetchAfdelingen(): Promise<Afdeling[]> {
@@ -185,7 +182,7 @@ export async function fetchAfdelingen(): Promise<Afdeling[]> {
             ],
         },
     });
-    return response.data.data.map((it) => it.attributes);
+    return unwrapList(response);
 }
 
 export async function fetchAfdeling(slug: string): Promise<AfdelingDetail> {
@@ -202,12 +199,12 @@ export async function fetchAfdeling(slug: string): Promise<AfdelingDetail> {
         },
     });
 
-    function sanitise(afdeling: any): Afdeling {
-        afdeling.banner = afdeling.banner.data?.attributes?.url ?? null;
-        return afdeling;
+    const afdeling = unwrapFirstEntity<any>(response);
+    if (!afdeling) {
+        throw new Error(`Afdeling not found: ${slug}`);
     }
-
-    return sanitise(response.data.data[0].attributes);
+    afdeling.banner = unwrapMediaUrl(afdeling.banner);
+    return afdeling;
 }
 
 export async function fetchPostSlugs(): Promise<{
@@ -222,8 +219,8 @@ export async function fetchPostSlugs(): Promise<{
     });
 
     return {
-        slugs: response.data.data.map((it) => it.attributes.slug),
-        pagination: response.data.meta.pagination,
+        slugs: unwrapList(response).map((it) => it.slug),
+        pagination: unwrapPagination(response),
     };
 }
 
@@ -282,17 +279,15 @@ export async function fetchPosts(
         },
     });
 
-    function sanitise(post: any): Post {
-        post.afdeling = post.afdeling.data?.attributes ?? null;
-        const formats = post.banner.data?.attributes?.formats;
-        const format = formats?.large ?? formats?.small ?? formats?.thumbnail;
-        post.banner = format?.url ?? null;
+    const posts = unwrapList<any>(response).map((post): Post => {
+        post.afdeling = unwrapRelation(post.afdeling);
+        post.banner = pickLargestMediaFormatUrl(unwrapMediaFormats(post.banner));
         return post;
-    }
+    });
 
     return {
-        posts: response.data.data.map((it) => sanitise(it.attributes)),
-        pagination: response.data.meta.pagination,
+        posts,
+        pagination: unwrapPagination(response),
     };
 }
 
@@ -304,8 +299,7 @@ export async function fetchAuthors(): Promise<string[]> {
         },
     });
 
-    const uniqueAuthors = new Set(response.data.data.map((it) => it.attributes.author));
-
+    const uniqueAuthors = new Set(unwrapList(response).map((it) => it.author));
     return [...uniqueAuthors];
 }
 
@@ -329,16 +323,17 @@ export async function fetchPost(slug: string): Promise<PostDetail> {
         },
     });
 
-    async function sanitise(post: any) {
-        post.afdeling = post.afdeling.data?.attributes ?? null;
-        post.banner = post.banner.data?.attributes?.url ?? null;
-        if (post.petition && post.petition.data) {
-            post.petition = await fetchPetition(post.petition.data.id);
-        }
-        return post;
+    const post = unwrapFirstEntity<any>(response);
+    if (!post) {
+        throw new Error(`Post not found: ${slug}`);
     }
-
-    return sanitise(response.data.data[0].attributes);
+    post.afdeling = unwrapRelation(post.afdeling);
+    post.banner = unwrapMediaUrl(post.banner);
+    const petitionRef = unwrapRelationWithId<unknown>(post.petition);
+    if (petitionRef) {
+        post.petition = await fetchPetition(petitionRef.id);
+    }
+    return post;
 }
 
 export async function fetchConfidantsPage(): Promise<ConfidantsPageContent> {
@@ -355,12 +350,9 @@ export async function fetchConfidantsPage(): Promise<ConfidantsPageContent> {
         }
     );
 
-    function sanitise(content: any) {
-        content.banner = content.banner.data.attributes.url;
-        return content;
-    }
-
-    return sanitise(response.data.data.attributes);
+    const content = unwrapEntity<any>(response);
+    content.banner = unwrapMediaUrl(content.banner);
+    return content;
 }
 
 export async function fetchConfidants(): Promise<Confidant[]> {
@@ -375,12 +367,10 @@ export async function fetchConfidants(): Promise<Confidant[]> {
         },
     });
 
-    function sanitise(confidant: any): Confidant {
-        confidant.photo = confidant.photo.data?.attributes?.url ?? null;
+    return unwrapList<any>(response).map((confidant) => {
+        confidant.photo = unwrapMediaUrl(confidant.photo);
         return confidant;
-    }
-
-    return response.data.data.map((it) => sanitise(it.attributes));
+    });
 }
 
 export async function fetchWorkgroupsPage(): Promise<WorkgroupPageContent> {
@@ -397,12 +387,9 @@ export async function fetchWorkgroupsPage(): Promise<WorkgroupPageContent> {
         }
     );
 
-    function sanitise(content: any) {
-        content.banner = content.banner.data.attributes.url;
-        return content;
-    }
-
-    return sanitise(response.data.data.attributes);
+    const content = unwrapEntity<any>(response);
+    content.banner = unwrapMediaUrl(content.banner);
+    return content;
 }
 
 export async function fetchWorkgroups(): Promise<Workgroup[]> {
@@ -412,11 +399,7 @@ export async function fetchWorkgroups(): Promise<Workgroup[]> {
         },
     });
 
-    function sanitise(confidant: any): Workgroup {
-        return confidant;
-    }
-
-    return response.data.data.map((it) => sanitise(it.attributes));
+    return unwrapList(response);
 }
 
 export async function fetchPetitionSlugs(): Promise<{
@@ -434,8 +417,8 @@ export async function fetchPetitionSlugs(): Promise<{
     });
 
     return {
-        slugs: response.data.data.map((it) => it.attributes.slug),
-        pagination: response.data.meta.pagination,
+        slugs: unwrapList(response).map((it) => it.slug),
+        pagination: unwrapPagination(response),
     };
 }
 

--- a/frontend/src/utils/strapi-response.ts
+++ b/frontend/src/utils/strapi-response.ts
@@ -1,0 +1,73 @@
+import { AxiosResponse } from "axios";
+import {
+    StrapiListResponse,
+    StrapiMediaField,
+    StrapiMediaFormats,
+    StrapiPagination,
+    StrapiRelationField,
+    StrapiResponse,
+} from "../models/strapi";
+
+// Re-exported so a fetcher only needs to import from one place to both type
+// a raw Strapi response and unwrap it.
+export type {
+    StrapiMediaField,
+    StrapiMediaFormats,
+    StrapiRelationField,
+    WithRawMedia,
+    WithRawRelation,
+} from "../models/strapi";
+
+export function unwrapEntity<T>(res: AxiosResponse<StrapiResponse<T>>): T {
+    return res.data.data.attributes;
+}
+
+export function unwrapList<T>(res: AxiosResponse<StrapiListResponse<T>>): T[] {
+    return res.data.data.map((it) => it.attributes);
+}
+
+export function unwrapFirstEntity<T>(
+    res: AxiosResponse<StrapiListResponse<T>>
+): T | null {
+    const first = res.data.data[0];
+    return first ? first.attributes : null;
+}
+
+export function unwrapPagination(
+    res: AxiosResponse<StrapiListResponse<unknown>>
+): StrapiPagination {
+    return res.data.meta.pagination;
+}
+
+export function unwrapMediaUrl(field: StrapiMediaField): string | null {
+    return field?.data?.attributes?.url ?? null;
+}
+
+export function unwrapMediaFormats(field: StrapiMediaField): StrapiMediaFormats | null {
+    return field?.data?.attributes?.formats ?? null;
+}
+
+export function pickLargestMediaFormatUrl(
+    formats: StrapiMediaFormats | null
+): string | null {
+    if (!formats) return null;
+    return (
+        formats.large?.url ??
+        formats.medium?.url ??
+        formats.small?.url ??
+        formats.thumbnail?.url ??
+        null
+    );
+}
+
+export function unwrapRelation<T>(field: StrapiRelationField<T>): T | null {
+    return field?.data?.attributes ?? null;
+}
+
+export function unwrapRelationWithId<T>(
+    field: StrapiRelationField<T>
+): (T & { id: number }) | null {
+    const data = field?.data;
+    if (!data) return null;
+    return { ...data.attributes, id: data.id };
+}


### PR DESCRIPTION
## What this does
Moves every `data.attributes` and `media.data.attributes.url` access out of `backend.ts` into a typed helper module so the eventual switch to Strapi 5's flat response shape is one diff in one file, not 34 edits across the fetcher.

- New `frontend/src/utils/strapi-response.ts` with helpers: `unwrapEntity`, `unwrapList`, `unwrapFirstEntity`, `unwrapPagination`, `unwrapMediaUrl`, `unwrapMediaFormats`, `pickLargestMediaFormatUrl`, `unwrapRelation`, `unwrapRelationWithId`.
- All 22 fetchers in `backend.ts` refactored to use them.
- Shared Strapi field types (`StrapiMediaField`, `StrapiMediaFormats`, `StrapiMediaAttributes`, `StrapiRelationField`) hoisted into `models/strapi.ts` so the shape lives in one place.
- New `WithRawMedia<T, K>` and `WithRawRelation<T, K, R>` utility types let future per-domain fetcher modules type a raw Strapi response in one line, no `<any>` needed:
  ```ts
  type HomeContentRaw = WithRawMedia<HomeContent, "banner">;
  const raw = unwrapEntity<HomeContentRaw>(response);
  return { ...raw, banner: unwrapMediaUrl(raw.banner) };
  ```

No runtime behaviour change. `tsc --noEmit` and `prettier --check` both clean.

## How this fits the Strapi 5 chain

| PR | Job |
|---|---|
| **#377 (this)** | Centralise the frontend's understanding of the v4 response shape in one file. |
| #378 | Backend middleware that re-wraps v5 responses into v4 shape. Ships disabled. |
| #379 | Smoke-test script that diffs every public endpoint before vs after the upgrade. |
| #380 | Bump Strapi to 5.46.0 and flip #378's middleware on. |
| follow-up | Drop the v4 unwrapping from the helpers when the frontend starts reading v5 natively. |

#377 and #378 are independent (neither imports the other) and can land in either order. Both need to be in before #380.

## A few things worth flagging
- `Fallback.pageBanner: string` is nullable at runtime but typed as non-null. Kept the existing `as string` cast with a comment instead of fixing the lie here, because fixing it cascades into `Banner` and 6 page files.
- Three small behaviour changes:
  - `fetchPost` and `fetchAfdeling` now throw named errors on empty results instead of a `TypeError`.
  - `pickLargestMediaFormatUrl` adds `medium` to the format fallback chain (was `large -> small -> thumbnail`).
  - Banner accesses that used to throw on missing media now return `null`. #379's smoke-test catches anything that regresses because of this; capture the baseline against current `main` before merging.

## Related
- Counterpart on the backend: #378 (independent, neither PR imports the other).
- Verification: #379 (smoke-test script).
- Depends on this + #378: #380 (Strapi 5 upgrade).