### PR TITLE
feat(backend): add Strapi v4 response shape middleware (disabled)

### DIFF
--- a/backend/config/middlewares.js
+++ b/backend/config/middlewares.js
@@ -9,4 +9,8 @@ module.exports = [
     "strapi::session",
     "strapi::favicon",
     "strapi::public",
+    {
+        name: "global::strapi-v4-response-shape",
+        config: { enabled: false },
+    },
 ];

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
         "build": "strapi build",
         "start-prod": "strapi build && strapi start",
         "strapi": "strapi",
-        "import-backup": "strapi import --file ../roodjongeren-export.tar.gz"
+        "import-backup": "strapi import --file ../roodjongeren-export.tar.gz",
+        "test": "node --test tests/*.test.js"
     },
     "dependencies": {
         "@babel/core": "^7.0.0",

--- a/backend/src/middlewares/strapi-v4-response-shape.js
+++ b/backend/src/middlewares/strapi-v4-response-shape.js
@@ -1,0 +1,115 @@
+"use strict";
+
+/**
+ * Strapi 4 -> 5 transition shim.
+ *
+ * When enabled, this middleware re-wraps Strapi 5 flat REST responses back
+ * into the v4 envelope shape ({ data: { id, attributes }, meta }, with nested
+ * media and relations re-wrapped as { data: { id, attributes } } / { data: [...] }).
+ *
+ * Scope: only /api/* responses. Custom controllers that return non-enveloped
+ * payloads (no top-level `data` key) are passed through unchanged.
+ *
+ * Removed once the frontend natively reads the v5 shape.
+ *
+ * Note on relation detection: in Strapi 5 every content-type row carries a
+ * string `documentId`. Components and JSON-stored objects do NOT. We use the
+ * presence of `documentId` to tell wrappable relations/media/entities apart
+ * from inline values that must pass through unchanged. Without this guard a
+ * petition's `extraQuestions` component or a JSON column with an `id` field
+ * would be incorrectly wrapped as `{ data: [...] }` and break v4 consumers.
+ *
+ * Known limitation: an empty has-many relation (`tags: []`) cannot be
+ * distinguished from an empty scalar array without schema awareness, so
+ * empty arrays pass through unchanged. Current frontend consumers don't hit
+ * this case; if a future caller needs it, switch to schema lookup via
+ * `strapi.contentTypes[uid]`.
+ */
+
+const MIDDLEWARE_NAME = "strapi-v4-response-shape";
+
+function hasIdentifier(value) {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        (typeof value.id === "number" || typeof value.id === "string")
+    );
+}
+
+function isWrappableEntity(value) {
+    return (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value) &&
+        typeof value.documentId === "string"
+    );
+}
+
+function toV4Field(value) {
+    if (Array.isArray(value)) {
+        if (value.length > 0 && value.every(isWrappableEntity)) {
+            return { data: value.map(toV4Entity) };
+        }
+        return value.map(toV4Field);
+    }
+    if (isWrappableEntity(value)) {
+        return { data: toV4Entity(value) };
+    }
+    return value;
+}
+
+function toV4Entity(entity) {
+    if (!hasIdentifier(entity)) return entity;
+    const { id, documentId, ...rest } = entity;
+    // In v5 the public identifier is documentId (string); the numeric id is
+    // internal. Expose documentId as the v4 `id` field so URLs that consumers
+    // build from this value (e.g. /api/petitions/:id) hit the v5 default
+    // router which expects documentId. Fall back to the numeric id for rows
+    // without a documentId (e.g. legacy tables).
+    const publicId = documentId !== undefined ? documentId : id;
+    const attributes = {};
+    for (const key of Object.keys(rest)) {
+        attributes[key] = toV4Field(rest[key]);
+    }
+    return { id: publicId, attributes };
+}
+
+function toV4Response(body) {
+    if (!body || typeof body !== "object" || Array.isArray(body)) return body;
+    if (!Object.prototype.hasOwnProperty.call(body, "data")) return body;
+
+    const { data, meta } = body;
+    if (Array.isArray(data)) {
+        return { ...body, data: data.map(toV4Entity), meta: meta ?? {} };
+    }
+    if (hasIdentifier(data)) {
+        return { ...body, data: toV4Entity(data), meta: meta ?? {} };
+    }
+    return body;
+}
+
+module.exports = (config, { strapi }) => {
+    const enabled = Boolean(config && config.enabled);
+    if (enabled) {
+        strapi.log.info(`[${MIDDLEWARE_NAME}] enabled`);
+    }
+
+    return async (ctx, next) => {
+        await next();
+
+        if (!enabled) return;
+        if (!ctx.path || !ctx.path.startsWith("/api/")) return;
+
+        const body = ctx.body;
+        if (!body || typeof body !== "object") return;
+
+        ctx.body = toV4Response(body);
+    };
+};
+
+// Exported for tests.
+module.exports.toV4Response = toV4Response;
+module.exports.toV4Entity = toV4Entity;
+module.exports.hasIdentifier = hasIdentifier;
+module.exports.isWrappableEntity = isWrappableEntity;

--- a/backend/tests/strapi-v4-response-shape.test.js
+++ b/backend/tests/strapi-v4-response-shape.test.js
@@ -1,0 +1,291 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+    toV4Response,
+    toV4Entity,
+    hasIdentifier,
+    isWrappableEntity,
+} = require("../src/middlewares/strapi-v4-response-shape.js");
+
+// ---------------------------------------------------------------------------
+// hasIdentifier — accepts any object with a numeric or string id. Used to
+// decide whether to descend into `toV4Entity`, not to decide wrapping.
+// ---------------------------------------------------------------------------
+
+test("hasIdentifier: true for object with numeric id", () => {
+    assert.equal(hasIdentifier({ id: 1 }), true);
+});
+
+test("hasIdentifier: true for object with string id", () => {
+    assert.equal(hasIdentifier({ id: "abc" }), true);
+});
+
+test("hasIdentifier: false for null", () => {
+    assert.equal(hasIdentifier(null), false);
+});
+
+test("hasIdentifier: false for array", () => {
+    assert.equal(hasIdentifier([{ id: 1 }]), false);
+});
+
+test("hasIdentifier: false for plain object without id", () => {
+    assert.equal(hasIdentifier({ name: "x" }), false);
+});
+
+// ---------------------------------------------------------------------------
+// isWrappableEntity — only true when `documentId` is present. This is the
+// signal that distinguishes content-type rows (which must be wrapped in the
+// v4 `{ data: { id, attributes } }` envelope) from components and JSON-stored
+// objects (which must stay inline).
+// ---------------------------------------------------------------------------
+
+test("isWrappableEntity: true when documentId is present", () => {
+    assert.equal(isWrappableEntity({ id: 1, documentId: "abc" }), true);
+});
+
+test("isWrappableEntity: false for a component (id but no documentId)", () => {
+    assert.equal(isWrappableEntity({ id: 1, question: "q?" }), false);
+});
+
+test("isWrappableEntity: false for a JSON column object with an id field", () => {
+    assert.equal(isWrappableEntity({ id: "json-x", value: 42 }), false);
+});
+
+// ---------------------------------------------------------------------------
+// toV4Entity
+// ---------------------------------------------------------------------------
+
+test("toV4Entity: exposes documentId as the v4 id and strips it from attributes", () => {
+    const result = toV4Entity({
+        id: 1,
+        documentId: "abc",
+        title: "Hello",
+        publishedAt: "2026-01-01",
+    });
+    assert.deepEqual(result, {
+        id: "abc",
+        attributes: { title: "Hello", publishedAt: "2026-01-01" },
+    });
+});
+
+test("toV4Entity: falls back to numeric id when documentId is absent", () => {
+    const result = toV4Entity({ id: 7, name: "no-doc" });
+    assert.deepEqual(result, { id: 7, attributes: { name: "no-doc" } });
+});
+
+// ---------------------------------------------------------------------------
+// toV4Response — top-level envelope handling
+// ---------------------------------------------------------------------------
+
+test("toV4Response: single entity envelope uses documentId as id", () => {
+    const v5 = {
+        data: { id: 1, documentId: "abc", title: "Hello", banner: null },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.equal(v4.data.id, "abc");
+    assert.equal(v4.data.attributes.title, "Hello");
+    assert.equal(v4.data.attributes.banner, null);
+});
+
+test("toV4Response: list envelope with pagination", () => {
+    const v5 = {
+        data: [
+            { id: 1, documentId: "doc-a", name: "A" },
+            { id: 2, documentId: "doc-b", name: "B" },
+        ],
+        meta: { pagination: { page: 1, pageSize: 10, pageCount: 1, total: 2 } },
+    };
+    const v4 = toV4Response(v5);
+    assert.equal(v4.data.length, 2);
+    assert.equal(v4.data[0].id, "doc-a");
+    assert.equal(v4.data[0].attributes.name, "A");
+    assert.equal(v4.meta.pagination.total, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Nested wrapping — media, single relation, list relation
+// ---------------------------------------------------------------------------
+
+test("toV4Response: nested media field is re-wrapped", () => {
+    const v5 = {
+        data: {
+            id: 1,
+            documentId: "post-1",
+            title: "T",
+            banner: {
+                id: 99,
+                documentId: "media-x",
+                url: "/u.jpg",
+                formats: { large: { url: "/L.jpg" } },
+            },
+        },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.equal(v4.data.attributes.banner.data.id, "media-x");
+    assert.equal(v4.data.attributes.banner.data.attributes.url, "/u.jpg");
+    assert.equal(v4.data.attributes.banner.data.attributes.formats.large.url, "/L.jpg");
+});
+
+test("toV4Response: nested relation single is re-wrapped", () => {
+    const v5 = {
+        data: {
+            id: 1,
+            documentId: "post-1",
+            title: "P",
+            afdeling: { id: 5, documentId: "rel-y", name: "Noord", slug: "noord" },
+        },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.equal(v4.data.attributes.afdeling.data.id, "rel-y");
+    assert.equal(v4.data.attributes.afdeling.data.attributes.name, "Noord");
+    assert.equal(v4.data.attributes.afdeling.data.attributes.slug, "noord");
+});
+
+test("toV4Response: nested has-many relation is re-wrapped", () => {
+    const v5 = {
+        data: {
+            id: 1,
+            documentId: "post-1",
+            tags: [
+                { id: 10, documentId: "tag-foo", name: "foo" },
+                { id: 11, documentId: "tag-bar", name: "bar" },
+            ],
+        },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.equal(v4.data.attributes.tags.data.length, 2);
+    assert.equal(v4.data.attributes.tags.data[0].id, "tag-foo");
+    assert.equal(v4.data.attributes.tags.data[0].attributes.name, "foo");
+});
+
+// ---------------------------------------------------------------------------
+// Inline pass-through — components, JSON columns, null relations, empty
+// arrays. These are the cases an earlier version of the middleware wrapped
+// incorrectly.
+// ---------------------------------------------------------------------------
+
+test("toV4Response: component repeater (objects with id, no documentId) stays inline", () => {
+    const v5 = {
+        data: {
+            id: 1,
+            documentId: "petition-1",
+            extraQuestions: [
+                { id: 1, question: "Age?", required: true },
+                { id: 2, question: "City?", required: false },
+            ],
+        },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    // Component stays inline — must NOT be wrapped as { data: [...] }.
+    assert.ok(Array.isArray(v4.data.attributes.extraQuestions));
+    assert.equal(v4.data.attributes.extraQuestions.length, 2);
+    assert.equal(v4.data.attributes.extraQuestions[0].question, "Age?");
+});
+
+test("toV4Response: single component (object with id, no documentId) stays inline", () => {
+    const v5 = {
+        data: {
+            id: 1,
+            documentId: "page-1",
+            seo: { id: 9, metaTitle: "T", metaDescription: "D" },
+        },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.deepEqual(v4.data.attributes.seo, {
+        id: 9,
+        metaTitle: "T",
+        metaDescription: "D",
+    });
+});
+
+test("toV4Response: JSON column with an id field stays inline (not wrapped)", () => {
+    const v5 = {
+        data: {
+            id: 1,
+            documentId: "post-1",
+            metadata: { id: "json-x", label: "foo" },
+        },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.deepEqual(v4.data.attributes.metadata, { id: "json-x", label: "foo" });
+});
+
+test("toV4Response: null single relation passes through as null", () => {
+    const v5 = {
+        data: { id: 1, documentId: "post-1", afdeling: null },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    // Frontend optional-chaining (field?.data?.attributes) coalesces both
+    // null and { data: null } to null, so this is safe in practice.
+    assert.equal(v4.data.attributes.afdeling, null);
+});
+
+test("toV4Response: empty has-many relation passes through as []", () => {
+    // Documented limitation: without schema awareness an empty has-many
+    // relation cannot be distinguished from an empty scalar array. Current
+    // frontend consumers don't hit this case; locked in as the expected
+    // behaviour until a caller needs `{ data: [] }`.
+    const v5 = {
+        data: { id: 1, documentId: "post-1", tags: [] },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.deepEqual(v4.data.attributes.tags, []);
+});
+
+// ---------------------------------------------------------------------------
+// Pass-through for non-entity bodies
+// ---------------------------------------------------------------------------
+
+test("toV4Response: custom controller body without data key passes through", () => {
+    const custom = { signatureCount: 5, id: 1, hook: "x" };
+    const out = toV4Response(custom);
+    assert.deepEqual(out, custom);
+});
+
+test("toV4Response: error response with data: null passes through", () => {
+    const err = { data: null, error: { status: 404, message: "Not Found" } };
+    const out = toV4Response(err);
+    assert.deepEqual(out, err);
+});
+
+test("toV4Response: missing meta defaults to empty object", () => {
+    const v5 = { data: { id: 1, documentId: "x", name: "x" } };
+    const v4 = toV4Response(v5);
+    assert.deepEqual(v4.meta, {});
+});
+
+test("toV4Response: primitive scalar in attributes is preserved", () => {
+    const v5 = {
+        data: {
+            id: 1,
+            documentId: "x",
+            title: "T",
+            count: 42,
+            active: true,
+            tags: ["a", "b"],
+        },
+        meta: {},
+    };
+    const v4 = toV4Response(v5);
+    assert.equal(v4.data.attributes.count, 42);
+    assert.equal(v4.data.attributes.active, true);
+    assert.deepEqual(v4.data.attributes.tags, ["a", "b"]);
+});
+
+test("toV4Response: non-object body is returned as-is", () => {
+    assert.equal(toV4Response(null), null);
+    assert.equal(toV4Response("string"), "string");
+    assert.equal(toV4Response(42), 42);
+});


### PR DESCRIPTION
## What this does
When enabled, this middleware takes Strapi 5's flat `/api/*` responses and re-wraps them into the old v4 envelope (`{ data: { id, attributes }, meta }`) so the existing frontend keeps working unchanged.

Ships disabled. The Strapi 5 upgrade in #380 flips it on. Once the frontend reads v5 natively, this middleware gets deleted.

## Relation to #377
The two PRs are paired in idea, not in code. Neither imports anything from the other, and they can land in either order.

- **#377** moves the frontend's understanding of the v4 shape into one file.
- **#378 (this)** keeps the backend producing the same v4 shape after the upgrade.

When #380 enables this middleware, the backend keeps speaking v4, the frontend keeps reading v4, and we have one obvious place to change on each side when we eventually drop the shim.

## How it decides what to wrap
Strapi 5's content-type rows carry a string `documentId`. Components and JSON-stored objects don't. The middleware wraps anything with a `documentId` (relations, media, top-level entities) and leaves everything else alone. Without that distinction, a petition's `extraQuestions` component repeater (or any JSON column with an `id` field) would get wrapped incorrectly and break v4 consumers.

`toV4Entity` still falls back to the numeric `id` when `documentId` is missing, so legacy or non-content-type rows keep working.

## One known limit
An empty has-many relation (`tags: []`) is indistinguishable from an empty scalar array without looking at the schema, so empty arrays pass through untouched. Nothing in the current frontend hits this case. If a future caller needs `{ data: [] }`, switch to a schema lookup via `strapi.contentTypes[uid]`.

## Notes
- Custom controller responses (no top-level `data` key) and error bodies pass through unchanged.
- 25 unit tests with `node:test`, including coverage for components, JSON columns with `id`, null relations, and empty has-many relations. Run with `yarn test` in `backend/`.
- `test` script uses `tests/*.test.js` shell glob. Node's native directory walk for `--test` is version-dependent; the glob is portable.
- No new dependencies.
- `packageManager` pinning is not in this PR on purpose. The codemod added a `yarn@4.14.1` line but the rest of the monorepo is on yarn 1. Repo-wide yarn / Node pinning lives in roadmap T2 so all three `package.json` files agree.

## Related
- Counterpart on the frontend: #377 (independent).
- Enabled by #380 (Strapi 5 upgrade).
- Verified end-to-end by #379 (smoke-test script).
- Test scaffold stacked on this branch: #381.