### PR TITLE
fix(a11y): add _document.tsx with html lang="nl"

### DIFF
--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from "next/document";
+
+export default function Document() {
+    return (
+        <Html lang="nl">
+            <Head />
+            <body>
+                <Main />
+                <NextScript />
+            </body>
+        </Html>
+    );
+}


### PR DESCRIPTION
## Description

Adds `frontend/src/pages/_document.tsx` so the rendered HTML carries `<html lang="nl">`. Today the site has no `lang` attribute, so screen readers fall back to the OS locale and pronounce Dutch with English phonemes. WCAG 2.2 SC 3.1.1 is a hard fail without this.