### PR TITLE
chore: add PR template, CODEOWNERS, SECURITY.md, CONTRIBUTING.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Codeowners are auto-requested for review on PRs that touch their paths.
+# This file is *advisory* until branch protection is configured to require
+# code-owner review (see SECURITY.md).
+
+# Default owner for everything not matched below.
+* @Nowa-Ammerlaan @RubenNijhuis
+
+# Backend (Strapi)
+/backend/                       @Nowa-Ammerlaan @RubenNijhuis
+
+# Frontend (Next.js)
+/frontend/                      @Nowa-Ammerlaan @RubenNijhuis
+
+# Infra & deploy
+/docker/                        @Nowa-Ammerlaan @RubenNijhuis
+/scripts/                       @Nowa-Ammerlaan @RubenNijhuis
+
+# CI / governance
+/.github/                       @Nowa-Ammerlaan @RubenNijhuis

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Keep this short. Reviewers care about: what changed, why, how to test, how to roll back. -->
+
+## What
+<!-- 1-3 sentences. What does this PR change? -->
+
+## Why
+<!-- The motivation. Linked issue, user-visible problem, etc. -->
+
+## Test plan
+<!-- How did you verify this? Manual steps, automated tests, screenshots. -->
+- [ ]
+
+## Rollback
+<!-- How do we revert if something breaks in prod? "Revert this commit" is fine for most. -->
+
+## Related
+<!-- Linked issues / other PRs / external context. Delete if none. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to roodjongeren.nl
+
+Thanks for helping out. This guide is short on purpose; the goal is to get
+you to a green PR without a lot of friction.
+
+## Setup
+
+See [`README.md`](./README.md) for the full local-development setup. The
+short version:
+
+```bash
+# Start the supporting services (Postgres, Nginx, Mailcatcher)
+docker compose -f docker/roodjongeren_dev/docker-compose.yml up -d
+
+# Backend
+cd backend
+yarn install
+yarn dev   # http://localhost:1337
+
+# Frontend (separate terminal)
+cd frontend
+yarn install
+yarn dev   # http://localhost:3000
+```
+
+If port 80 (Nginx) is already taken on your machine, override the host port:
+
+```bash
+NGINX_HOST_PORT=8081 docker compose ...
+```
+
+The same pattern works for `POSTGRES_HOST_PORT`, `MAILCATCHER_SMTP_HOST_PORT`,
+`MAILCATCHER_WEB_HOST_PORT`. Make sure `DATABASE_PORT` in `backend/.env`
+matches whatever you set for Postgres.
+
+## Tooling
+
+- Node and yarn versions are pinned in `.tool-versions`. Use `mise` or
+  `asdf` to keep them straight, or just match them manually.
+- Yarn 1 across the monorepo. Don't let corepack pull in yarn 4 by accident.
+- Prettier formats. Run `yarn lint:prettier` at the repo root before opening
+  a PR.
+- TypeScript on the frontend (`cd frontend && yarn ts-lint`).
+- ESLint on the frontend (`cd frontend && yarn lint`).
+- Backend test runner is built-in `node:test`. Run `yarn test` from
+  `backend/`.
+
+## Branches and commits
+
+- Branch off `main`. Name branches with a prefix like `feat/`, `fix/`,
+  `chore/`, `ci/`, `refactor/`. Keep them short.
+- Commit messages follow Conventional Commits loosely:
+  `type(scope): short summary`. Body explains the why, not the what.
+- PRs are squash-merged. Keep your commit history readable, but don't sweat
+  it; the squash commit message is what ends up on `main`.
+
+## Pull requests
+
+The repo has a PR template. Fill in:
+
+1. **What** changed (1-3 sentences).
+2. **Why** (the motivation, linked issue).
+3. **Test plan** (how you verified it, manual or automated).
+4. **Rollback** plan (often just "revert this commit").
+5. **Related** issues or PRs.
+
+Keep PRs small. If you can't describe the change in one or two sentences,
+split it.
+
+## Code review
+
+- Tag a code owner (`.github/CODEOWNERS`) plus anyone with relevant context.
+- Reviewers focus on: correctness, security, accessibility, and whether the
+  diff matches the description.
+- Don't merge your own PR without at least one approval, even if you have
+  the permissions.
+
+## Security
+
+See [`SECURITY.md`](./SECURITY.md) for how to report vulnerabilities. Don't
+open public issues for security problems.
+
+## Accessibility
+
+- Set `lang` on every page (Dutch by default; English when `next-intl` lands).
+- All interactive elements must be keyboard-operable (`<button>`, not
+  `<div onClick>`).
+- Images need meaningful `alt` text; decorative images get `alt=""`.
+- Form fields need associated labels (`htmlFor` matching `id`).
+- Targets WCAG 2.2 AA. When in doubt, run `axe` against your change.
+
+## Questions
+
+Open a discussion or ping the codeowners on Slack. We're friendly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security policy
+
+Thanks for taking the time to report a security issue with roodjongeren.nl.
+
+## Reporting a vulnerability
+
+If you've found something that could compromise user data, the petition flow,
+or the integrity of our public site, please **don't open a public GitHub issue**.
+
+Instead, email **security@roodjongeren.nl** with:
+
+- A short description of the issue.
+- Steps to reproduce or a proof of concept.
+- Your contact details so we can follow up.
+
+We aim to acknowledge reports within 3 working days and to provide a status
+update within 10 working days.
+
+If you'd prefer encrypted email, ask for our PGP key in the first message
+and we'll send it back through a separate channel.
+
+## Scope
+
+In scope:
+
+- The public site at `roodjongeren.nl`.
+- The Strapi admin at `roodjongeren.nl/backend/admin`.
+- The petition signature flow (form, confirmation, redirect).
+- Authenticated areas linked from the public site.
+
+Out of scope (not because they don't matter, but because they're handled
+elsewhere):
+
+- `mijn.roodjongeren.nl` (separate codebase, separate disclosure address).
+- Third-party services we link to.
+- Best-practice recommendations with no concrete vulnerability (e.g.
+  "you should add header X" without a demonstrated attack).
+
+## What we appreciate
+
+- Reports that include a clear repro and a proposed fix or mitigation.
+- Coordinated disclosure (we credit researchers in release notes if you'd
+  like).
+- Patience while we triage; this is a small volunteer team.
+
+## What we don't appreciate
+
+- Automated scanner output without manual validation.
+- Testing that disrupts the service for real users (rate-limit testing,
+  spam, etc.). Please request permission first.
+- Attempts to access data that isn't yours.


### PR DESCRIPTION
## Description

Adds OSS-baseline contributor infrastructure the repo never had: a short PR template, CODEOWNERS, SECURITY.md, and CONTRIBUTING.md. Four new top-level files, zero code changes.

## ⚠️ Blocked on confirmations

- `security@roodjongeren.nl` in `SECURITY.md` - confirm the mailbox/alias exists or substitute a real one.
- `@Nowa-Ammerlaan` and `@RubenNijhuis` in `CODEOWNERS` - confirm these are the right owners per area, or split per backend/frontend/docker/scripts.