### PR TITLE
ci: add CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+    schedule:
+        # Weekly Monday 06:00 UTC. Catches new CodeQL rules even on quiet weeks.
+        - cron: "0 6 * * 1"
+
+jobs:
+    analyze:
+        name: Analyze ${{ matrix.language }}
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+
+        strategy:
+            fail-fast: false
+            matrix:
+                language: ["javascript-typescript"]
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: ${{ matrix.language }}
+                  queries: security-and-quality
+
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v3
+
+            - name: Perform CodeQL analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Description

Wires GitHub-native CodeQL static analysis into CI: runs on PRs to main, pushes to main, and a weekly schedule (newly-published rules surface even when the repo is quiet). Free for public repos, zero third-party signup.

## Related

Pairs with #392 (Trivy).