### PR TITLE
fix: show 404 page on missing post or afdeling (closes #32)

### DIFF
--- a/frontend/src/pages/afdelingen/[slug].tsx
+++ b/frontend/src/pages/afdelingen/[slug].tsx
@@ -116,9 +116,15 @@ export async function getStaticProps(
 ): Promise<GetStaticPropsResult<Props>> {
     const params = context.params as Params;
 
-    const [{ pageBanner }, afdeling, { posts }] = await Promise.all([
+    let afdeling: Afdeling;
+    try {
+        afdeling = await fetchAfdeling(params.slug);
+    } catch {
+        return { notFound: true, revalidate };
+    }
+
+    const [{ pageBanner }, { posts }] = await Promise.all([
         fetchFallback(),
-        fetchAfdeling(params.slug),
         fetchPosts(undefined, undefined, params.slug, 1, 8),
     ]);
 

--- a/frontend/src/pages/post/[slug].tsx
+++ b/frontend/src/pages/post/[slug].tsx
@@ -61,10 +61,13 @@ export async function getStaticPaths(): Promise<GetStaticPathsResult> {
 export async function getStaticProps(context: GetStaticPropsContext) {
     const params = context.params as Params;
 
-    const [post, { pageBanner }] = await Promise.all([
-        fetchPost(params.slug),
-        fetchFallback(),
-    ]);
+    let post: PostDetail;
+    try {
+        post = await fetchPost(params.slug);
+    } catch {
+        return { notFound: true, revalidate };
+    }
+    const { pageBanner } = await fetchFallback();
 
     return {
         props: { post, fallbackBanner: pageBanner },


### PR DESCRIPTION
## Description

Returns a proper 404 instead of a blank black screen when a post or afdeling slug doesn't exist. After #377 made the unwrappers throw named errors (`Post not found`, `Afdeling not found`), the page-level catch turns those into Next's `{ notFound: true }` and `pages/404.tsx` renders. Closes #32.