### PR TITLE
feat(a11y): :focus-visible baseline and prefers-reduced-motion fallback

### DIFF
--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -53,3 +53,21 @@ html {
 .leaflet-control-attribution .leaflet-attribution-flag {
     display: none !important;
 }
+
+:focus-visible {
+    outline: 2px solid #ffd400;
+    outline-offset: 2px;
+    border-radius: 2px;
+}
+
+/* 0.01ms (not 0) keeps transitionend events firing so JS-driven animations don't hang. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}


### PR DESCRIPTION
## Description

Adds two global CSS rules in `globals.css`. First, a 2px yellow `:focus-visible` outline so keyboard focus is visible everywhere; today Tailwind only outlines elements that explicitly opt in, so most of the site has invisible focus. Second, a `prefers-reduced-motion: reduce` block that collapses all animations to ~0.01ms for users who've asked the OS to reduce motion. WCAG 2.4.7 (Focus Visible) and 2.3.3 (Animation from Interactions).