### PR TITLE
fix(smoke-test): pass curl -g and drop nonexistent support-us endpoint

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -56,7 +56,6 @@ ENDPOINTS=(
     "about-us|/api/about-us?populate[banner][fields][0]=url"
     "program|/api/program?populate[banner][fields][0]=url"
     "join-us|/api/join-us?populate[banner][fields][0]=url"
-    "support-us|/api/support-us?populate[banner][fields][0]=url"
     "privacybeleid|/api/privacybeleid"
     "confidants-page|/api/confidants-page?populate[banner][fields][0]=url"
     "workgroups-page|/api/workgroups-page?populate[banner][fields][0]=url"
@@ -116,7 +115,10 @@ snapshot() {
 
     printf '%-22s GET %s\n' "$name" "$url"
 
-    local curl_flags=(-sS -H "Accept: application/json")
+    # `-g` disables curl's URL-globbing so `[` and `]` (used in Strapi v4
+    # query syntax, e.g. `populate[banner][fields][0]=url`) are sent
+    # literally instead of being treated as a range expression.
+    local curl_flags=(-sS -g -H "Accept: application/json")
     if [[ $mode == "fail" ]]; then
         curl_flags+=(-f)
     fi


### PR DESCRIPTION
## Description

Two bugs in `scripts/smoke-test.sh` caught while running it against a real v5 backend during #380 verification:

1. **Strapi v4 query syntax uses square brackets** (e.g. `populate[banner][fields][0]=url`), and curl interprets `[` / `]` as a URL range expression and refuses to send. Add `-g` to disable URL globbing so the brackets are sent literally. Without this, 8 of the 17 endpoints fail with `curl: (3) bad range in URL` and never get snapshotted.

2. **`/api/support-us` was in the endpoint list** but no `support-us` content type exists in the backend. The 404 produced a misleading "FAILED" line and an empty 0-byte file in the snapshot. Removed.

## How to verify

- `bash scripts/smoke-test.sh /tmp/test-snap http://localhost:1337` against any running backend.
- Before: about half the endpoints print `curl: (3) bad range in URL` lines.
- After: every endpoint prints just the URL and writes a populated `.json` file (assuming the backend is reachable and content types exist).

## Out of scope

The frontend has a matching dead `fetchSupportUs()` in `frontend/src/utils/backend.ts` along with a `SupportUsContent` model. Removing those is unrelated to the smoke-test fix and can land separately.