### PR TITLE
fix(a11y): name banner chevron link and raise text-faded contrast

### DIFF
--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -52,7 +52,12 @@ export default function Banner(props: Props) {
 function ContentLink() {
     return (
         <div className="mt-12">
-            <a href="#main-content" className="inline-block group" tabIndex={-1}>
+            <a
+                href="#main-content"
+                className="inline-block group"
+                tabIndex={-1}
+                aria-label="Naar de inhoud"
+            >
                 <div className="flex mt-12 opacity-80 group-hover:opacity-100 transition-opacity">
                     <div className="h-[3px] w-14 bg-white transition-colors origin-right rotate-45" />
                     <div className="h-[3px] w-14 bg-white transition-colors origin-left -rotate-45" />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -13,7 +13,7 @@ module.exports = {
                 primary: "#C2000B",
                 secondary: "#111111",
                 regular: "#565656",
-                faded: "#9b9b9b",
+                faded: "#737373",
             },
             backgroundImage: {
                 banner: "url('/images/banner.webp')",


### PR DESCRIPTION
## Description

Two pre-existing serious axe-core violations on every public page.

- **`link-name`**: the banner's chevron link to `#main-content` wraps two rotated divs and had no accessible name. Adds `aria-label="Naar de inhoud"`. Visual unchanged.
- **`color-contrast`**: `text-faded` was `#9b9b9b` (2.85:1 on white, fails WCAG 2.2 AA). Bumped to `#737373` (4.54:1).

Used on attribution lines, table headers, the Markdown pull-quote icon, and a few empty-state strings.