### PR TITLE
fix(a11y): make header hamburger and dropdown real buttons

### DIFF
--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -25,6 +25,15 @@ export default function Header() {
         setMenuOpen(false);
     }, [router.pathname]);
 
+    useEffect(() => {
+        if (!isMenuOpen) return;
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setMenuOpen(false);
+        };
+        window.addEventListener("keydown", handleKey);
+        return () => window.removeEventListener("keydown", handleKey);
+    }, [isMenuOpen]);
+
     return (
         <header className="fixed w-full top-0 z-[2000] shadow-[#0002] shadow-md bg-white overflow-y-auto md:overflow-visible">
             <SkipToContent />
@@ -44,18 +53,23 @@ export default function Header() {
                             />
                         </div>
                     </Link>
-                    <div
-                        className="lg:hidden text-2xl inline-block mr-4"
+                    <button
+                        type="button"
+                        className="lg:hidden text-2xl inline-block mr-4 focus-visible:outline-2 focus-visible:outline-primary"
                         onClick={() => setMenuOpen(!isMenuOpen)}
+                        aria-expanded={isMenuOpen}
+                        aria-controls="primary-navigation"
+                        aria-label={isMenuOpen ? "Sluit menu" : "Open menu"}
                     >
                         {isMenuOpen ? (
-                            <FaTimes className="inline-block" />
+                            <FaTimes className="inline-block" aria-hidden="true" />
                         ) : (
-                            <FaBars className="inline-block" />
+                            <FaBars className="inline-block" aria-hidden="true" />
                         )}
-                    </div>
+                    </button>
                 </div>
                 <div
+                    id="primary-navigation"
                     className={`grow flex flex-col lg:flex-row items-stretch duration-500 easy-in-out
                              lg:max-h-full ${
                                  isMenuOpen ? "max-h-screen" : "max-h-0 overflow-hidden"

--- a/frontend/src/components/header/HeaderDropdown.tsx
+++ b/frontend/src/components/header/HeaderDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import React, { ReactNode, useCallback, useEffect, useId, useRef, useState } from "react";
 import { FaCaretDown } from "react-icons/fa";
 import { useRouter } from "next/router";
 
@@ -11,59 +11,73 @@ export default function HeaderDropdown(props: Props) {
     const router = useRouter();
     const [isOpen, setOpen] = useState<boolean>(false);
 
-    const dropdownRef = useRef<any>(null);
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
+    const panelId = useId();
     const handleToggleMenu = useCallback(
-        (e: React.MouseEvent) => setOpen((prevState) => !prevState),
+        () => setOpen((prevState) => !prevState),
         [setOpen]
     );
-
-    const handleFocus = useCallback(() => setOpen(true), [setOpen]);
-    const handleBlur = useCallback(() => setOpen(false), [setOpen]);
 
     useEffect(() => {
         setOpen(false);
     }, [router.pathname]);
 
     useEffect(() => {
+        if (!isOpen) return;
         const handleClickOutside = (e: MouseEvent) => {
-            const wasClickedOutsideOfDropdown = !dropdownRef.current?.contains(e.target);
-            if (wasClickedOutsideOfDropdown) {
+            const target = e.target as Node | null;
+            if (target && !wrapperRef.current?.contains(target)) {
                 setOpen(false);
             }
         };
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setOpen(false);
+        };
         window.addEventListener("click", handleClickOutside);
-        return () => window.removeEventListener("click", handleClickOutside);
-    }, [setOpen, dropdownRef]);
+        window.addEventListener("keydown", handleKey);
+        return () => {
+            window.removeEventListener("click", handleClickOutside);
+            window.removeEventListener("keydown", handleKey);
+        };
+    }, [isOpen]);
+
+    const handleBlur = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+            setOpen(false);
+        }
+    }, []);
 
     return (
-        <div className="flex flex-col grow">
-            <div
-                className="flex relative grow items-center justify-center relative p-4 cursor-pointer whitespace-nowrap relative group text-4xl font-title"
+        <div className="flex flex-col grow" ref={wrapperRef} onBlur={handleBlur}>
+            <button
+                type="button"
+                className="flex relative grow items-center justify-center p-4 cursor-pointer whitespace-nowrap group text-4xl font-title focus-visible:outline-2 focus-visible:outline-primary"
                 onClick={handleToggleMenu}
-                ref={dropdownRef}
+                aria-expanded={isOpen}
+                aria-controls={panelId}
+                aria-haspopup="true"
             >
                 <span>
                     {props.title}
                     <FaCaretDown
+                        aria-hidden="true"
                         className={`inline ml-2 transition-transform ${
                             isOpen ? "rotate-180" : "rotate-0"
                         }`}
                     />
                 </span>
-                <div className="absolute bottom-0 transition-transform w-full origin-bottom h-[14px] group-hover:scale-y-100 group-active:scale-y-100 bg-primary z-50 scale-y-0" />
-            </div>
+                <div
+                    aria-hidden="true"
+                    className="absolute bottom-0 transition-transform w-full origin-bottom h-[14px] group-hover:scale-y-100 group-active:scale-y-100 bg-primary z-50 scale-y-0"
+                />
+            </button>
             <div
+                id={panelId}
                 className={`lg:absolute inner-shadow bg-white overflow-hidden transition-all top-[calc(100%+1rem)] ${
                     isOpen ? "max-h-screen" : "max-h-0"
                 }`}
             >
-                <div
-                    className="lg:p-4 shadow-inner bg-gray-50"
-                    onFocus={handleFocus}
-                    onBlur={handleBlur}
-                >
-                    {props.children}
-                </div>
+                <div className="lg:p-4 shadow-inner bg-gray-50">{props.children}</div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

Makes the mobile hamburger and the "Over ons" dropdown keyboard-operable and screen-reader-correct by replacing `<div onClick>` toggles with real buttons carrying `aria-expanded` / `aria-controls`, plus Escape-to-close. Closes the largest open a11y gap from the Wave 3.5 punch list.

## How to test

- Tab to hamburger / dropdown trigger, toggle with Enter or Space.
- Open dropdown, Tab through items — panel stays open.
- Press Escape — panel closes.
- Click outside the open panel — panel closes.

## References

- Backlog item F11 (`improvements.md`)